### PR TITLE
Add Docker support for easy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log*
+Dockerfile
+docker-compose.yml
+.git
+.gitignore
+.env
+logs

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # WhatsApp AI Bot Configuration
 
 # Server Configuration
-PORT=3001
+PORT=3091
 NODE_ENV=development
 
 # WAHA (WhatsApp HTTP API) Configuration
-WAHA_URL=http://localhost:3000
+WAHA_URL=http://localhost:3001
 WAHA_SESSION_NAME=default
 
 # OpenRouter API Configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use official Node.js 18 image
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci --only=production
+
+# Copy application source
+COPY . .
+
+# Expose port
+EXPOSE 3001
+
+# Start the server
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ A Node.js application that integrates WhatsApp with AI models through OpenRouter
 - 📊 Real-time status monitoring
 - 🎯 QR code display for WhatsApp connection
 
+## Quick Start with Docker
+
+Follow these steps to run the bot in a container:
+
+1. **Install Docker**  
+   [Docker Desktop](https://docs.docker.com/get-docker/) includes Docker Compose.
+
+2. **Prepare environment variables**  
+   Copy the example file and tweak values as needed:
+   ```bash
+   cp .env.example .env
+   ```
+
+3. **Build and start the service**  
+   ```bash
+   docker compose up --build
+   ```
+
+4. **Verify it works**  
+   Wait for the logs to show `Server is running on port 3001` then visit http://localhost:3001 or check:
+   ```bash
+   curl http://localhost:3001/health
+   ```
+
+Stop the containers with `Ctrl+C` and remove them with `docker compose down` when finished.
+
 ## Prerequisites
 
 - Node.js 18+ installed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build: .
@@ -9,3 +8,25 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+      - "3091:3091"
+    environment:
+      WAHA_URL: http://waha:3000
+    depends_on:
+      waha:
+        condition: service_healthy # ← wait for WAHA to be healthy
+    env_file: .env
+
+  waha:
+    image: devlikeapro/waha:latest
+    platform: linux/amd64 # <— remove this line
+    ports:
+      - "3001:3000"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:3000 >/dev/null 2>&1 || exit 1",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - "3001:3001"
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs


### PR DESCRIPTION
## Summary
- Add Dockerfile using Node 18 and exposing port 3001
- Provide docker-compose.yml for one-command startup with volume mounts
- Ignore unnecessary files in Docker builds
- Document Docker usage with step-by-step setup instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run check`
- `docker compose up --build` *(fails: command not found; apt repositories 403 when attempting installation)*

------
https://chatgpt.com/codex/tasks/task_b_68b205c09c508328bc68f12af5db7fb5